### PR TITLE
Fixed issues with distributed cache (see LDEV-3279)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target
 target/*
 *.lock
 *.DS_Store
+.vscode/launch.json

--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Fri May 27 09:05:50 EDT 2022
-build.number=36
+#Tue Jul 05 10:30:03 EDT 2022
+build.number=37

--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Fri Aug 26 15:43:35 EDT 2022
-build.number=38
+#Thu Sep 22 07:53:47 EDT 2022
+build.number=39

--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Tue Jul 05 10:30:03 EDT 2022
-build.number=37
+#Fri Aug 26 15:43:35 EDT 2022
+build.number=38

--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Thu Sep 06 23:20:19 CEST 2018
-build.number=32
+#Fri May 27 09:05:50 EDT 2022
+build.number=36

--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Thu Sep 22 07:53:47 EDT 2022
-build.number=39
+#Tue Nov 01 09:31:21 EDT 2022
+build.number=40

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 bundlename: ehcache.extension
 filename: ehcache-extension
-bundleversion: 2.10.0.
+bundleversion: 2.10.1.
 bundleversionappendix: -SNAPSHOT
 id: 87FE44E5-179C-43A3-A87B3D38BEF4652E
 label: EHCache

--- a/source/CFML/src/context/admin/cdriver/EHCache.cfc
+++ b/source/CFML/src/context/admin/cdriver/EHCache.cfc
@@ -90,10 +90,10 @@
 		,field("Replicate Asynchronously","replicateAsynchronously","true",true,"whether replications are
       asynchronous (checked) or synchronous (unchecked), .","checkbox",'true')
 		
-		,field("Replicate Puts","replicatePuts","true",true,"whether new elements placed in a cache are replicated to others.","checkbox",'true')
-		,field("Replicate Puts Via Copy","replicatePutsViaCopy","true",true,"whether the new elements are copied to other caches (checked), or whether a remove message is sent.","checkbox",'true')
+		,field("Replicate Puts","replicatePuts","false",true,"whether new elements placed in a cache are replicated to others.","checkbox",'true')
+		,field("Replicate Puts Via Copy","replicatePutsViaCopy","false",true,"whether the new elements are copied to other caches (checked), or whether a remove message is sent.<br><br><small><strong>IMPORTANT</strong> — Enabling this option requires that objects are serialized, which can involve significant overhead, especially when caching components. For best performance, leave this disabled, and then the cache items will just be marked for removal in other nodes instead of pushing a serialized object to the nodes.</small>","checkbox",'true')
 		,field("Replicate Updates","replicateUpdates","true",true,"whether new elements which override an element already existing with the same key are replicated","checkbox",'true')
-		,field("Replicate Updates Via Copy","replicateUpdatesViaCopy","true",true,"whether the new elements are copied to other caches (checked), or whether a remove message is sent.","checkbox",'true')
+		,field("Replicate Updates Via Copy","replicateUpdatesViaCopy","false",true,"whether the new elements are copied to other caches (checked), or whether a remove message is sent.<br><br><small><strong>IMPORTANT</strong> — Enabling this option requires that objects are serialized, which can involve significant overhead, especially when caching components. For best performance, leave this disabled, and then the cache items will just be marked for removal in other nodes instead of pushing a serialized object to the nodes.</small>","checkbox",'true')
 		,field("Replicate Removals","replicateRemovals","true",true,"whether element removals are replicated.","checkbox",'true')
 		,field("Asynchronous Replication Intervall","asynchronousReplicationIntervalMillis","1000",true,"The asynchronous replicator runs at a set interval of milliseconds (has no impact when ""Replicate Asynchronously"" is not checked)","text")
 		

--- a/source/java/.classpath
+++ b/source/java/.classpath
@@ -7,6 +7,7 @@
 	<classpathentry kind="lib" path="libs/jsp-api-2.2.jar"/>
 	<classpathentry kind="lib" path="libs/org.apache.felix.framework-4.2.1.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/loader"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/runtime"/>
 	<classpathentry kind="lib" path="libs/lucee.jar"/>
 	<classpathentry kind="lib" path="libs/org.lucee.ehcache-2.10.3.jar"/>
 	<classpathentry kind="output" path="bin"/>

--- a/source/java/.project
+++ b/source/java/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1652803992565</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/source/java/.project
+++ b/source/java/.project
@@ -14,15 +14,4 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1652803992565</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/source/java/src/org/lucee/extension/cache/eh/EHCache.java
+++ b/source/java/src/org/lucee/extension/cache/eh/EHCache.java
@@ -56,8 +56,9 @@ import org.lucee.extension.cache.eh.rmi.LuceeRMICacheReplicatorFactory;
 import org.lucee.extension.cache.eh.util.CacheUtil;
 import org.lucee.extension.cache.eh.util.TypeUtil;
 
+import lucee.commons.io.log.Log;
+
 public class EHCache extends EHCacheSupport {
-	
 	
 	
 	static {
@@ -89,8 +90,7 @@ public class EHCache extends EHCacheSupport {
 	private String cacheName;
 	private ClassLoader classLoader;
 	private CacheManagerAndHash mah;
-	
-	
+		
 	public static void flushAllCaches() {
 		String[] names;
 		Iterator<Map<String, CacheManagerAndHash>> _it = managersColl.values().iterator();
@@ -272,7 +272,8 @@ public class EHCache extends EHCacheSupport {
 	}
 
 	private static String createXML(String path, String cacheName,Struct arguments, String hash, RefBoolean isDistributed) {
-		//boolean isDistributed=false;
+		getLogger().debug("ehcache", "Building ehCache XML...");
+
 		isDistributed.setValue(false);
 		StringBuilder xml=new StringBuilder();
 		xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
@@ -282,7 +283,6 @@ public class EHCache extends EHCacheSupport {
 		xml.append("<diskStore path=\"");
 		xml.append(path);
 		xml.append("\"/>\n");
-		xml.append("<cacheManagerEventListenerFactory class=\"\" properties=\"\"/>\n");
 		
 		
 		// RMI
@@ -304,10 +304,6 @@ public class EHCache extends EHCacheSupport {
 					add+" \" />\n");
 			
 			//hostName=fully_qualified_hostname_or_ip,
-			
-			// listener
-			xml.append("<cacheManagerPeerListenerFactory class=\""+RMICacheManagerPeerListenerFactory.class.getName()+"\"/>\n");
-			
 		}
 		// Manual
 		else if(arguments!=null && arguments.get("distributed","").equals("manual")){
@@ -318,10 +314,17 @@ public class EHCache extends EHCacheSupport {
 			String add = arguments.get("manual_addional","").toString().trim();
 			if(!Util.isEmpty(add) && !add.startsWith(","))add=","+add;
 			add=add.replace('\n', ' ');
-			xml.append(" properties=\"peerDiscovery=manual, rmiUrls="+arguments.get("manual_rmiUrls","").toString().trim().toLowerCase().replace('\n', ' ')+
+			xml.append(" properties=\"peerDiscovery=manual, rmiUrls="+arguments.get("manual_rmiUrls","").toString().trim().replace('\n', ' ')+
 					add+"\"/>\n"); //propertySeparator=\",\" 
+		}
+
 		
-			// listener
+		// Whenever RMI is being used, we must add the listener properties so we can bind
+		// to the specified ports in the administration.
+		//
+		// This is important for "automatic" as well, so that we can configure specific
+		// ports to use instead of having ehCache bind to an ephemeral port.
+		if( isDistributed.toBooleanValue() ){
 			StringBuilder sb=new StringBuilder();
 			
 			String hostName=arguments.get("listener_hostName","").toString().trim().toLowerCase();
@@ -333,13 +336,16 @@ public class EHCache extends EHCacheSupport {
 			String socketTimeoutMillis = arguments.get("listener_socketTimeoutMillis","").toString().trim().toLowerCase();
 			if(!Util.isEmpty(socketTimeoutMillis) && !"120000".equals(socketTimeoutMillis)) 
 				add(sb,"socketTimeoutMillis="+socketTimeoutMillis);
-			
+
+			getLogger().debug("ehcache", "Remote port = " + remoteObjectPort);
+				
 			xml.append("<cacheManagerPeerListenerFactory"); 
 			xml.append(" class=\""+RMICacheManagerPeerListenerFactory.class.getName()+"\""); 
 			if(sb.length()>0)xml.append(" properties=\""+sb+"\""); 
 			xml.append("/>\n");
-			
-			
+		// for non-distributed caches, we write an empty event listener
+		} else {
+			xml.append("<cacheManagerEventListenerFactory class=\"\" properties=\"\"/>\n");
 		}
 
 		xml.append("<defaultCache \n");
@@ -359,7 +365,13 @@ public class EHCache extends EHCacheSupport {
 		createCacheXml(xml,cacheName,arguments,isDistributed.toBooleanValue());
 		
 		xml.append("</ehcache>\n");
-		return xml.toString();
+
+		String xmlContents = xml.toString();
+
+		getLogger().debug("ehcache", "Finished building ehCache XML...");
+		getLogger().debug("ehcache", "ehcache.xml = \n" + xmlContents);
+
+		return xmlContents;
 	}
 	
 	
@@ -473,10 +485,12 @@ public class EHCache extends EHCacheSupport {
 		// env stuff
 		System.setProperty("net.sf.ehcache.enableShutdownHook", "true");
 		try {
+			getLogger().debug("ehcache", "Setting class loader context...");
 			this.classLoader=CacheUtil.getClassLoaderEnv(config);
 			setClassLoader();
 			
 		} catch (PageException pe) {
+			getLogger().error("ehcache", "Failed to set class loader context...");
 			throw CFMLEngineFactory.getInstance().getExceptionUtil().toIOException(pe);
 		}
 		
@@ -494,6 +508,9 @@ public class EHCache extends EHCacheSupport {
 		
 		// get manager for that specific configuration (arguments)
 		mah=managers.get(hashArgs);
+
+		getLogger().debug("ehcache", "mah = " + ((mah == null) ? "null" : mah.toString()));
+
 		if(mah==null) {
 			Resource hashDir=dir.getRealResource(hashArgs);
 			if(!hashDir.isDirectory())hashDir.createDirectory(true);
@@ -502,6 +519,11 @@ public class EHCache extends EHCacheSupport {
 			mah=new CacheManagerAndHash(xml);// "ehcache_"+config.getIdentification().getId()
 			managers.put(hashArgs, mah);
 			this.isDistributed=isDistributed.toBooleanValue();
+			if( this.isDistributed ){
+				// we should serialize the results if we are putting copies of the elements in the cache
+				this.isSerialized=(toBooleanValue(arguments.get("replicatePutsViaCopy",Boolean.FALSE),REPLICATE_PUTS_VIA_COPY) || toBooleanValue(arguments.get("replicateUpdatesViaCopy",Boolean.FALSE),REPLICATE_UPDATES_VIA_COPY)) ? true : false;
+			}
+			getLogger().debug("ehcache", "Writing EHCache XML!");
 			// write the xml
 			writeEHCacheXML(hashDir,xml);
 		}

--- a/source/java/src/org/lucee/extension/cache/eh/EHCache.java
+++ b/source/java/src/org/lucee/extension/cache/eh/EHCache.java
@@ -271,8 +271,8 @@ public class EHCache extends EHCacheSupport {
 		return hashes;
 	}
 
-	private static String createXML(String path, String cacheName,Struct arguments, String hash, RefBoolean isDistributed, Log LOG) {
-		LOG.debug("ehcache", "Building ehCache XML...");
+	private static String createXML(String path, String cacheName,Struct arguments, String hash, RefBoolean isDistributed, Log log) {
+		log.debug("ehcache", "Building ehCache XML...");
 
 		isDistributed.setValue(false);
 		StringBuilder xml=new StringBuilder();
@@ -337,7 +337,7 @@ public class EHCache extends EHCacheSupport {
 			if(!Util.isEmpty(socketTimeoutMillis) && !"120000".equals(socketTimeoutMillis)) 
 				add(sb,"socketTimeoutMillis="+socketTimeoutMillis);
 
-			LOG.debug("ehcache", "Remote port = " + remoteObjectPort);
+			log.debug("ehcache", "Remote port = " + remoteObjectPort);
 				
 			xml.append("<cacheManagerPeerListenerFactory"); 
 			xml.append(" class=\""+RMICacheManagerPeerListenerFactory.class.getName()+"\""); 
@@ -368,8 +368,8 @@ public class EHCache extends EHCacheSupport {
 
 		String xmlContents = xml.toString();
 
-		LOG.debug("ehcache", "Finished building ehCache XML...");
-		LOG.debug("ehcache", "ehcache.xml = \n" + xmlContents);
+		log.debug("ehcache", "Finished building ehCache XML...");
+		log.debug("ehcache", "ehcache.xml = \n" + xmlContents);
 
 		return xmlContents;
 	}
@@ -480,18 +480,18 @@ public class EHCache extends EHCacheSupport {
 	@Override
 	public void init(Config config,String cacheName,Struct arguments) throws IOException {
 		
-		Log LOG = getLogger();
+		Log log = getLogger();
 		this.cacheName=cacheName=improveCacheName(cacheName);
 		
 		// env stuff
 		System.setProperty("net.sf.ehcache.enableShutdownHook", "true");
 		try {
-			LOG.debug("ehcache", "Setting class loader context...");
+			log.debug("ehcache", "Setting class loader context...");
 			this.classLoader=CacheUtil.getClassLoaderEnv(config);
 			setClassLoader();
 			
 		} catch (PageException pe) {
-			LOG.error("ehcache", "Failed to set class loader context...", pe);
+			log.error("ehcache", "Failed to set class loader context...", pe);
 			throw CFMLEngineFactory.getInstance().getExceptionUtil().toIOException(pe);
 		}
 		
@@ -510,13 +510,13 @@ public class EHCache extends EHCacheSupport {
 		// get manager for that specific configuration (arguments)
 		mah=managers.get(hashArgs);
 
-		LOG.debug("ehcache", "mah = " + ((mah == null) ? "null" : mah.toString()));
+		log.debug("ehcache", "mah = " + ((mah == null) ? "null" : mah.toString()));
 
 		if(mah==null) {
 			Resource hashDir=dir.getRealResource(hashArgs);
 			if(!hashDir.isDirectory())hashDir.createDirectory(true);
 			RefBoolean isDistributed = CFMLEngineFactory.getInstance().getCreationUtil().createRefBoolean(false);
-			String xml=createXML(hashDir.getAbsolutePath(), cacheName,arguments,hashArgs,isDistributed,LOG);
+			String xml=createXML(hashDir.getAbsolutePath(), cacheName,arguments,hashArgs,isDistributed,log);
 			mah=new CacheManagerAndHash(xml);// "ehcache_"+config.getIdentification().getId()
 			managers.put(hashArgs, mah);
 			this.isDistributed=isDistributed.toBooleanValue();
@@ -524,7 +524,7 @@ public class EHCache extends EHCacheSupport {
 				// we should serialize the results if we are putting copies of the elements in the cache
 				this.isSerialized=(toBooleanValue(arguments.get("replicatePutsViaCopy",Boolean.FALSE),REPLICATE_PUTS_VIA_COPY) || toBooleanValue(arguments.get("replicateUpdatesViaCopy",Boolean.FALSE),REPLICATE_UPDATES_VIA_COPY)) ? true : false;
 			}
-			LOG.debug("ehcache", "Writing EHCache XML!");
+			log.debug("ehcache", "Writing EHCache XML!");
 			// write the xml
 			writeEHCacheXML(hashDir,xml);
 		}

--- a/source/java/src/org/lucee/extension/cache/eh/EHCacheEntry.java
+++ b/source/java/src/org/lucee/extension/cache/eh/EHCacheEntry.java
@@ -81,7 +81,7 @@ public class EHCacheEntry implements CacheEntry {
 
 	@Override
 	public Object getValue() {
-		return cache.isDistributed?TypeUtil.toCFML(element.getObjectValue()):element.getObjectValue();
+		return cache.isSerialized?TypeUtil.toCFML(element.getObjectValue()):element.getObjectValue();
 	}
 
 	public void setElement(Element element) {

--- a/source/java/src/org/lucee/extension/cache/eh/EHCacheSupport.java
+++ b/source/java/src/org/lucee/extension/cache/eh/EHCacheSupport.java
@@ -24,6 +24,7 @@ import lucee.commons.io.cache.Cache;
 import lucee.commons.io.cache.CacheEntry;
 import lucee.commons.io.cache.CachePro;
 import lucee.runtime.type.Struct;
+import lucee.runtime.config.Config;
 import net.sf.ehcache.Element;
 import net.sf.ehcache.config.CacheConfiguration;
 
@@ -36,9 +37,14 @@ public abstract class EHCacheSupport extends CacheSupport implements Cache {
 	
 	protected boolean isDistributed;
 	protected boolean isSerialized;
+	protected Log logger;
 
-	public static Log getLogger() {
-		Log logger = CFMLEngineFactory.getInstance().getThreadConfig().getLog("application");
+	protected Log getLogger() {
+		return getLogger(null);
+	}
+
+	protected Log getLogger(Config config) {
+		Log logger = (config==null?CFMLEngineFactory.getInstance().getThreadConfig():config).getLog("application");
 
 		// for some reason, setting the application log to "debug" does not always show
 		// the ehCache output, so when debugging code, we can just manually set the log

--- a/source/java/src/org/lucee/extension/cache/eh/rmi/LuceeRMICacheReplicatorFactory.java
+++ b/source/java/src/org/lucee/extension/cache/eh/rmi/LuceeRMICacheReplicatorFactory.java
@@ -102,6 +102,7 @@ public class LuceeRMICacheReplicatorFactory extends CacheEventListenerFactory {
         int maximumBatchSize = extractMaximumBatchSize(properties);
 
         if (replicateAsynchronously) {
+            this.log.debug("ehcache", "Replicating asynchronously...");
             return new LuceeRMIAsynchronousCacheReplicator(config,log,
                     replicatePuts,
                     replicatePutsViaCopy,
@@ -111,6 +112,7 @@ public class LuceeRMICacheReplicatorFactory extends CacheEventListenerFactory {
                     replicationIntervalMillis,
                     maximumBatchSize);
         } else {
+            this.log.debug("ehcache", "Replicating synchronously...");
             return new RMISynchronousCacheReplicator(
                     replicatePuts,
                     replicatePutsViaCopy,

--- a/source/java/src/org/lucee/extension/cache/eh/util/CacheUtil.java
+++ b/source/java/src/org/lucee/extension/cache/eh/util/CacheUtil.java
@@ -19,7 +19,6 @@
 package org.lucee.extension.cache.eh.util;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
 
 import lucee.commons.io.cache.Cache;
 import lucee.commons.io.cache.CacheEntry;
@@ -109,8 +108,7 @@ public class CacheUtil {
 
 	public static ClassLoader getClassLoaderEnv(Config config) throws PageException {
 		try {
-			Method m = config.getClass().getMethod("getClassLoaderEnv", new Class[0]);
-			return (ClassLoader) m.invoke(config, new Object[0]);
+			return new EHCacheClassLoader(config);
 		}
 		catch (Exception e) {
 			throw CFMLEngineFactory.getInstance().getCastUtil().toPageException(e);

--- a/source/java/src/org/lucee/extension/cache/eh/util/EHCacheClassLoader.java
+++ b/source/java/src/org/lucee/extension/cache/eh/util/EHCacheClassLoader.java
@@ -55,6 +55,13 @@ public class EHCacheClassLoader extends ClassLoader {
 		return null;
 	}
 
+	/*
+	 * We need to test if the class is a framework bundle and to do that, we need
+	 * to use reflection to get access to the private OSGiUtil isFrameworkBundle()
+	 * method.
+	 * 
+	 * IMPORTANT — If the method in the Lucee source code changes, this function will break.
+	 */
 	public boolean isFrameworkBundle(Bundle b){
 		try {
 			Class<?> clazz = CFMLEngineFactory.getInstance().getClassUtil().loadClass("lucee.runtime.osgi.OSGiUtil");

--- a/source/java/src/org/lucee/extension/cache/eh/util/EHCacheClassLoader.java
+++ b/source/java/src/org/lucee/extension/cache/eh/util/EHCacheClassLoader.java
@@ -1,0 +1,131 @@
+package org.lucee.extension.cache.eh.util;
+
+import java.lang.reflect.Method;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+
+import lucee.loader.engine.CFMLEngine;
+import lucee.loader.engine.CFMLEngineFactory;
+import lucee.runtime.config.Config;
+
+import lucee.commons.io.log.Log;
+
+
+/**
+ * A special class loader that first attempts to load class from the Lucee Environment,
+ * but that can fail when RMI classes are requested via a spawned thread, so when
+ * the class cannot be located in the Lucee Environment, it searches all the Felix
+ * bundles for the requested class. This will prevent issues with issues trying
+ * to load classes like net.sf.ehcache.distribution.RMICachePeer_Stub. 
+ *
+ * @author Dan G. Switzer, II
+ * @version 1.0
+ */
+public class EHCacheClassLoader extends ClassLoader {
+	private Config config;
+	private ClassLoader LuceeEnvClassLoader;
+
+	public EHCacheClassLoader(Config config) {
+		this.config = config;
+
+		try {
+			Method m = config.getClass().getMethod("getClassLoaderEnv", new Class[0]);
+			this.LuceeEnvClassLoader = (ClassLoader) m.invoke(config, new Object[0]);
+		}
+		catch (Exception e) {
+			// do nothing
+		}
+	}
+
+	public CFMLEngine getCFMLEngine(){
+		try {
+			Class<?> clazz = CFMLEngineFactory.getInstance().getClassUtil().loadClass("lucee.runtime.config.ConfigWebUtil");
+			Method m = clazz.getMethod("getEngine", new Class[] { Config.class });
+			return (CFMLEngine) m.invoke(null, this.config);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		return null;
+	}
+
+	public boolean isFrameworkBundle(Bundle b){
+		try {
+			Class<?> clazz = CFMLEngineFactory.getInstance().getClassUtil().loadClass("lucee.runtime.osgi.OSGiUtil");
+			Method m = clazz.getMethod("isFrameworkBundle", new Class[] { Bundle.class });
+			return (boolean) m.invoke(null, b);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	private Log getLogger() {
+		Log logger = this.config.getLog("application");
+
+		return logger;
+	}
+
+	public Class<?> loadClass(final String className) throws ClassNotFoundException {
+		Class<?> clazz = null;
+
+		Log log = getLogger();
+
+		log.debug("ehcache", "Loading class " + className);
+
+		// we should try the finding the class in the Lucee environmental class loader
+		if( this.LuceeEnvClassLoader != null ){
+			try {
+				clazz = (Class<?>)this.LuceeEnvClassLoader.loadClass(className);
+			} catch (ClassNotFoundException ex) {
+				// ignore that we cannot find the class
+				log.debug("ehcache", "Could not find class in EnvClassLoader.");
+			}
+		}
+		
+		log.debug("ehcache", "Could not find in normal class loader, searching Felix bundles...");
+		clazz = searchFelixBundleClasses(className);
+
+		if( clazz == null ){
+			log.error("ehcache", "Could not find class in any class loader!");
+			throw new ClassNotFoundException();
+		}
+
+		return clazz;
+	}
+
+	private synchronized Class<?> searchFelixBundleClasses(final String className){
+		Class<?> clazz = null;
+
+		// try to find the class in the Felix bundles
+		CFMLEngine engine = getCFMLEngine();
+
+		if (engine != null) {
+			BundleContext bc = engine.getBundleContext();
+			if (bc != null) {
+				Bundle[] bundles = bc.getBundles();
+				Bundle b = null;
+				for (int i = 0; i < bundles.length; i++) {
+					b = bundles[i];
+					//getLogger().debug("ehcache", "Searching " + b.getSymbolicName() + " bundle for " + className + " class.");
+					if (b != null && !isFrameworkBundle(b)) {
+						try {
+							getLogger().debug("ehcache", "Found in " + className + " class in " + b.getSymbolicName() + " bundle.");
+							return b.loadClass(className);
+						}
+						catch (Exception e) {
+							clazz = null;
+						}
+					}
+				}
+			}
+		}
+
+		return clazz;
+	}
+	
+	public ClassLoader getClassLoader() {
+		return EHCacheClassLoader.class.getClassLoader();
+	}
+
+}

--- a/source/java/src/org/lucee/extension/cache/eh/util/EHCacheClassLoader.java
+++ b/source/java/src/org/lucee/extension/cache/eh/util/EHCacheClassLoader.java
@@ -79,15 +79,15 @@ public class EHCacheClassLoader extends ClassLoader {
 				clazz = (Class<?>)this.LuceeEnvClassLoader.loadClass(className);
 			} catch (ClassNotFoundException ex) {
 				// ignore that we cannot find the class
-				log.debug("ehcache", "Could not find class in EnvClassLoader.");
+				log.debug("ehcache", "Could not find " + className + " class in EnvClassLoader.");
 			}
 		}
 		
-		log.debug("ehcache", "Could not find in normal class loader, searching Felix bundles...");
+		log.debug("ehcache", "Could not find " + className + " in normal class loader, searching Felix bundles...");
 		clazz = searchFelixBundleClasses(className);
 
 		if( clazz == null ){
-			log.error("ehcache", "Could not find class in any class loader!");
+			log.debug("ehcache", "Could not find " + className + " class in any class loader!");
 			throw new ClassNotFoundException();
 		}
 
@@ -106,15 +106,19 @@ public class EHCacheClassLoader extends ClassLoader {
 				Bundle[] bundles = bc.getBundles();
 				Bundle b = null;
 				for (int i = 0; i < bundles.length; i++) {
+					clazz = null;
 					b = bundles[i];
 					//getLogger().debug("ehcache", "Searching " + b.getSymbolicName() + " bundle for " + className + " class.");
 					if (b != null && !isFrameworkBundle(b)) {
 						try {
-							getLogger().debug("ehcache", "Found in " + className + " class in " + b.getSymbolicName() + " bundle.");
-							return b.loadClass(className);
+							clazz = b.loadClass(className);
 						}
 						catch (Exception e) {
 							clazz = null;
+						}
+						if( clazz != null ){
+							getLogger().debug("ehcache", "Found in " + className + " class in " + b.getSymbolicName() + " bundle.");
+							return clazz;
 						}
 					}
 				}

--- a/source/java/src/org/lucee/extension/cache/eh/util/TypeUtil.java
+++ b/source/java/src/org/lucee/extension/cache/eh/util/TypeUtil.java
@@ -10,7 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
+import java.io.Serializable;
 
+import org.lucee.extension.cache.eh.EHCacheSupport;
 import org.lucee.extension.cache.util.print;
 
 import lucee.loader.engine.CFMLEngineFactory;
@@ -21,6 +23,7 @@ import lucee.runtime.type.Struct;
 import lucee.runtime.type.dt.DateTime;
 import lucee.runtime.type.dt.TimeSpan;
 import lucee.runtime.util.Creation;
+import lucee.runtime.Component;
 
 public class TypeUtil {
 	
@@ -35,7 +38,16 @@ public class TypeUtil {
 		if(value==null) return null;
 		//print.e("jvm:"+value.getClass().getName());
 		
-		if(value instanceof Collection) {
+		// DateTime
+		if(value instanceof DateTime) {
+			return new Date(((DateTime)value).getTime());
+		}
+		// TimeSpan
+		if(value instanceof TimeSpan) {
+			return ((TimeSpan)value).castToDoubleValue(0);
+		}
+
+		if(value instanceof Collection && !(value instanceof Component)) {
 			// Array
 			if(value instanceof Array) {
 				List<Object> list=new LinkedList<Object>();
@@ -64,23 +76,17 @@ public class TypeUtil {
 		// Component
 		// UDF
 		
-		
-		// DateTime
-		if(value instanceof DateTime) {
-			return new Date(((DateTime)value).getTime());
-		}
-		// TimeSpan
-		if(value instanceof TimeSpan) {
-			return ((TimeSpan)value).castToDoubleValue(0);
-		}
 		ClassLoader cl = value.getClass().getClassLoader();
+
 		if(cl!=null && cl!=ClassLoader.getSystemClassLoader()) {
 			try {
-				return "lucee-serialized:"+SerializerUtil.serialize(value);
+				return "lucee-serialized:"+SerializerUtil.serialize((Serializable) value);
 			}
-			catch (Exception e) {}
+			catch (Exception e) {
+				print.e("Could not serialize item \"" + value.toString() + "\" in toJVM()");
+				print.e(e);
+			}
 		}
-		
 		
 		
 		return value;
@@ -88,7 +94,6 @@ public class TypeUtil {
 	
 	public static Object toCFML(Object value) {
 		if(value==null) return null;
-		//print.e("cfml:"+value.getClass().getName());
 		
 		if(value instanceof LinkedList) {
 			Iterator it = ((LinkedList)value).iterator();
@@ -111,7 +116,10 @@ public class TypeUtil {
 			try {
 				return SerializerUtil.evaluate(((String)value).substring(17));
 			}
-			catch (Exception e) {}
+			catch (Exception e) {
+				print.e("Could not deserialize item \"" + value.toString() + "\" in toCFML()");
+				print.e(e);
+			}
 		}
 		return value;
 	}

--- a/source/java/src/org/lucee/extension/cache/eh/util/TypeUtil.java
+++ b/source/java/src/org/lucee/extension/cache/eh/util/TypeUtil.java
@@ -83,8 +83,8 @@ public class TypeUtil {
 				return "lucee-serialized:"+SerializerUtil.serialize((Serializable) value);
 			}
 			catch (Exception e) {
-				print.e("Could not serialize item \"" + value.toString() + "\" in toJVM()");
-				print.e(e);
+				// print.e("Could not serialize item \"" + value.toString() + "\" in toJVM()");
+				// print.e(e);
 			}
 		}
 		
@@ -117,8 +117,8 @@ public class TypeUtil {
 				return SerializerUtil.evaluate(((String)value).substring(17));
 			}
 			catch (Exception e) {
-				print.e("Could not deserialize item \"" + value.toString() + "\" in toCFML()");
-				print.e(e);
+				// print.e("Could not deserialize item \"" + value.toString() + "\" in toCFML()");
+				// print.e(e);
 			}
 		}
 		return value;


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-3279

* Added EHCacheClassLoader to resolve issues with loading RMI classes
* The <cacheManagerEventListenerFactory /> settings are now always honored (previously the properties were only populated when set to "manual" distribution mode, but it's need for "automatic" mode in order to control the ports being used)
* Changed default ehCache distribution configuration for optimal performance by disable "via Copy" and "put" operations
* Refactored code so serialization only happens when replicating objects using the "via copy" options (other distributed cache options just mark the objects for removal, so serialization is not required)
* Fixed bug in TypeUtil.toJVM() which caused components to not be fully serialized (it was being treated as a struct and missing properties/methods extended from other components)

*IMPORTANT* — The `EHCacheClassLoader` uses reflection to access the `isFrameworkBundle` method on `lucee.runtime.osgi.OSGiUtil`. If that method was made public, we could avoid using reflection. @michaeloffner stated "we need to mark this in the Lucee core, that this is used in that extension and it should not be changed".