### PR TITLE
LDEV-4630 comprehensive EHCache test coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,78 +1,89 @@
-name: Java CI Combined
+name: Java CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'Deploy to Maven Central'
+        type: boolean
+        default: false
+      luceeVersions:
+        description: 'JSON array of Lucee versions to test'
+        required: false
+        default: '[ "6/snapshot/light", "7.0/snapshot/light", "7.1/snapshot/light" ]'
 
 jobs:
-  setup:
+  build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       version: ${{ steps.extract-version.outputs.VERSION }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
           java-version: '11'
+          distribution: 'temurin'
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-
 
       - name: Extract version number
         id: extract-version
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "::set-output name=VERSION::$VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build extension
+        run: mvn -B -e clean package
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ehcache-lex
+          path: target/*.lex
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        lucee: ${{ fromJSON(inputs.luceeVersions || '["6/snapshot/light", "7.0/snapshot/light", "7.1/snapshot/light"]') }}
+    steps:
+      - uses: actions/checkout@v6
 
       - name: Cache Lucee files
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/work/_actions/lucee/script-runner/main/lucee-download-cache
           key: lucee-downloads
 
-      - name: Import GPG key
-        run: |
-          echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --batch --import
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-
-  build-and-test:
-    runs-on: ubuntu-latest
-    needs: setup
-    env:
-      LUCEE_TEST_VERSIONS_PLUS: ${{ vars.LUCEE_TEST_VERSIONS_PLUS }}
-    strategy:
-      matrix:
-        lucee: ${{ fromJSON(vars.LUCEE_TEST_VERSIONS_PLUS) }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v4
+      - name: Download extension artifact
+        uses: actions/download-artifact@v8
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          name: ehcache-lex
+          path: target
 
-      - name: Build and Install with Maven
+      - name: Set up Postgres
         run: |
-          echo "------- Maven Install -------";
-          mvn -B -e -f pom.xml clean install
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ehcache-lex-${{ matrix.lucee.version }}
-          path: target/*.lex
+          sudo /etc/init.d/postgresql start
+          sudo -u postgres psql -c 'create database lucee;'
+          sudo -u postgres psql -c "create user lucee with encrypted password 'lucee'";
+          sudo -u postgres psql -c 'grant all privileges on database lucee to lucee;'
+          sudo -u postgres psql -c 'grant all on schema public to lucee;' -d lucee
 
       - name: Checkout Lucee
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: lucee/lucee
           path: lucee
@@ -82,34 +93,38 @@ jobs:
         with:
           webroot: ${{ github.workspace }}/lucee/test
           execute: /bootstrap-tests.cfm
-          luceeVersion: ${{ matrix.lucee.version }}
-          luceeVersionQuery: ${{ matrix.lucee.query }}
+          luceeVersion: ${{ matrix.lucee }}
           extensionDir: ${{ github.workspace }}/target
         env:
           testLabels: ehcache
           testAdditional: ${{ github.workspace }}/tests
+          LUCEE_ADMIN_PASSWORD: admin
+          POSTGRES_SERVER: localhost
+          POSTGRES_USERNAME: lucee
+          POSTGRES_PASSWORD: lucee
+          POSTGRES_PORT: 5432
+          POSTGRES_DATABASE: lucee
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [build-and-test]
-    if: always() && needs.build-and-test.result == 'success'
+    timeout-minutes: 15
+    needs: [build, test]
+    if: github.event_name == 'workflow_dispatch' && inputs.deploy
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-
 
       - name: Import GPG key
         run: |
@@ -119,14 +134,15 @@ jobs:
 
       - name: Build and Deploy with Maven
         env:
+          VERSION: ${{ needs.build.outputs.version }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          if [[ "${{ needs.setup.outputs.version }}" == *-SNAPSHOT ]]; then
-            echo "------- Maven Deploy snapshot on ${{ github.event_name }} -------";
-            mvn -B -e -f pom.xml clean deploy --settings maven-settings.xml
+          if [[ "$VERSION" == *-SNAPSHOT ]]; then
+            echo "------- Maven Deploy snapshot -------";
+            mvn -B -e clean deploy --settings maven-settings.xml
           else
-            echo "------- Maven Deploy release on ${{ github.event_name }} -------";
-            mvn -B -e -f pom.xml clean deploy -DperformRelease=true --settings maven-settings.xml
+            echo "------- Maven Deploy release -------";
+            mvn -B -e clean deploy -DperformRelease=true --settings maven-settings.xml
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target/*
 *.lock
 *.DS_Store
 .vscode/launch.json
+/test-output

--- a/tests/EHCacheBasicTest.cfc
+++ b/tests/EHCacheBasicTest.cfc
@@ -1,0 +1,103 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="ehcache" {
+
+	public function beforeAll() {
+		createCache();
+	}
+
+	public function run( testResults, testBox ) {
+
+		describe( "EHCache Basic Operations", function() {
+
+			beforeEach( function() {
+				cacheClear( "", "ehcacheBasic" );
+			});
+
+			it( "can put and get a value", function() {
+				cachePut( "basicKey", "hello world", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				var result = cacheGet( "basicKey", "ehcacheBasic" );
+				expect( result ).toBe( "hello world" );
+			});
+
+			it( "returns false for a cache miss", function() {
+				expect( cacheIdExists( "nonExistentKey_#createUUID()#", "ehcacheBasic" ) ).toBeFalse();
+			});
+
+			it( "reports contains correctly", function() {
+				cachePut( "existsKey", "value", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				expect( cacheIdExists( "existsKey", "ehcacheBasic" ) ).toBeTrue();
+				expect( cacheIdExists( "doesNotExist_#createUUID()#", "ehcacheBasic" ) ).toBeFalse();
+			});
+
+			it( "can remove an entry", function() {
+				cachePut( "removeMe", "gone soon", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				expect( cacheIdExists( "removeMe", "ehcacheBasic" ) ).toBeTrue();
+				cacheRemove( "removeMe", false, "ehcacheBasic" );
+				expect( cacheIdExists( "removeMe", "ehcacheBasic" ) ).toBeFalse();
+			});
+
+			it( "can clear all entries", function() {
+				cachePut( "clearA", "a", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				cachePut( "clearB", "b", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				cachePut( "clearC", "c", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				expect( cacheCount( "ehcacheBasic" ) ).toBe( 3 );
+				cacheClear( "", "ehcacheBasic" );
+				expect( cacheCount( "ehcacheBasic" ) ).toBe( 0 );
+			});
+
+			it( "can list keys", function() {
+				cachePut( "keyA", "a", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				cachePut( "keyB", "b", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				cachePut( "keyC", "c", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				var ids = cacheGetAllIds( cacheName: "ehcacheBasic" );
+				expect( ids ).toBeArray();
+				expect( arrayLen( ids ) ).toBe( 3 );
+			});
+
+			it( "can get all values", function() {
+				cachePut( "valA", "alpha", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				cachePut( "valB", "bravo", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				var all = cacheGetAll( cacheName: "ehcacheBasic" );
+				expect( all ).toBeStruct();
+				expect( structCount( all ) ).toBe( 2 );
+			});
+
+			it( "can overwrite an existing entry", function() {
+				cachePut( "overwrite", "first", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				expect( cacheGet( "overwrite", "ehcacheBasic" ) ).toBe( "first" );
+				cachePut( "overwrite", "second", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				expect( cacheGet( "overwrite", "ehcacheBasic" ) ).toBe( "second" );
+			});
+
+			it( "reports count correctly", function() {
+				expect( cacheCount( "ehcacheBasic" ) ).toBe( 0 );
+				cachePut( "countA", "a", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				cachePut( "countB", "b", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheBasic" );
+				expect( cacheCount( "ehcacheBasic" ) ).toBe( 2 );
+			});
+
+		});
+
+	}
+
+	private function createCache() {
+		application action="update" name="ehcacheBasicTest" caches={
+			"ehcacheBasic": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "1000",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "300",
+					"timeToLiveSeconds": "300",
+					"overflowtodisk": "true",
+					"diskpersistent": "false",
+					"maxelementsondisk": "10000",
+					"distributed": "off"
+				},
+				default: ""
+			}
+		};
+	}
+
+}

--- a/tests/EHCacheCachedWithin/Application.cfc
+++ b/tests/EHCacheCachedWithin/Application.cfc
@@ -1,0 +1,21 @@
+component {
+
+	this.name = "ehcacheCachedWithinTest-#hash( getCurrentTemplatePath() )#";
+
+	this.cache.function = {
+		class: "org.lucee.extension.cache.eh.EHCache",
+		storage: false,
+		custom: {
+			"eternal": "false",
+			"maxelementsinmemory": "1000",
+			"memoryevictionpolicy": "LRU",
+			"timeToIdleSeconds": "86400",
+			"timeToLiveSeconds": "86400",
+			"overflowtodisk": "false",
+			"diskpersistent": "false",
+			"maxelementsondisk": "0",
+			"distributed": "off"
+		}
+	};
+
+}

--- a/tests/EHCacheCachedWithin/cachedWithinFlush.cfm
+++ b/tests/EHCacheCachedWithin/cachedWithinFlush.cfm
@@ -1,0 +1,27 @@
+<cfscript>
+
+function getCachedValue( id ) cachedwithin="#createTimeSpan( 0, 1, 0, 0 )#" {
+	return createUUID();
+}
+
+function run() {
+	var first = getCachedValue( 1 );
+	var second = getCachedValue( 1 );
+
+	if ( first != second )
+		throw( message: "caching broken: first != second" );
+
+	var flushed = cachedWithinFlush( getCachedValue, [ 1 ] );
+	if ( !flushed )
+		throw( message: "cachedWithinFlush returned false" );
+
+	var third = getCachedValue( 1 );
+	if ( third == first )
+		throw( message: "value not flushed: third == first" );
+
+	echo( "PASS" );
+}
+
+run();
+
+</cfscript>

--- a/tests/EHCacheCachedWithin/cachedWithinFlushDouble.cfm
+++ b/tests/EHCacheCachedWithin/cachedWithinFlushDouble.cfm
@@ -1,0 +1,23 @@
+<cfscript>
+
+function getCachedValue( id ) cachedwithin="#createTimeSpan( 0, 1, 0, 0 )#" {
+	return createUUID();
+}
+
+function run() {
+	getCachedValue( 999 );
+
+	var r1 = cachedWithinFlush( getCachedValue, [ 999 ] );
+	if ( !r1 )
+		throw( message: "first flush should return true, got false" );
+
+	var r2 = cachedWithinFlush( getCachedValue, [ 999 ] );
+	if ( r2 )
+		throw( message: "second flush should return false, got true" );
+
+	echo( "PASS" );
+}
+
+run();
+
+</cfscript>

--- a/tests/EHCacheCachedWithin/cachedWithinFlushSelective.cfm
+++ b/tests/EHCacheCachedWithin/cachedWithinFlushSelective.cfm
@@ -1,0 +1,27 @@
+<cfscript>
+
+function getCachedValue( id ) cachedwithin="#createTimeSpan( 0, 1, 0, 0 )#" {
+	return createUUID();
+}
+
+function run() {
+	var val1 = getCachedValue( 10 );
+	var val2 = getCachedValue( 20 );
+
+	if ( getCachedValue( 10 ) != val1 || getCachedValue( 20 ) != val2 )
+		throw( message: "caching broken" );
+
+	cachedWithinFlush( getCachedValue, [ 10 ] );
+
+	if ( getCachedValue( 10 ) == val1 )
+		throw( message: "arg 10 was not flushed" );
+
+	if ( getCachedValue( 20 ) != val2 )
+		throw( message: "arg 20 was incorrectly flushed" );
+
+	echo( "PASS" );
+}
+
+run();
+
+</cfscript>

--- a/tests/EHCacheCachedWithin/cachedWithinId.cfm
+++ b/tests/EHCacheCachedWithin/cachedWithinId.cfm
@@ -1,0 +1,23 @@
+<cfscript>
+
+function getCachedValue( id ) cachedwithin="#createTimeSpan( 0, 1, 0, 0 )#" {
+	return createUUID();
+}
+
+function run() {
+	getCachedValue( 1 );
+
+	var idArr = cachedWithinId( getCachedValue, [ 1 ] );
+	if ( !isSimpleValue( idArr ) || len( idArr ) == 0 )
+		throw( message: "array args: expected non-empty string, got [#idArr#]" );
+
+	var idStruct = cachedWithinId( getCachedValue, { id: 1 } );
+	if ( idArr != idStruct )
+		throw( message: "array vs struct mismatch: [#idArr#] != [#idStruct#]" );
+
+	echo( "PASS" );
+}
+
+run();
+
+</cfscript>

--- a/tests/EHCacheCachedWithinTest.cfc
+++ b/tests/EHCacheCachedWithinTest.cfc
@@ -1,0 +1,56 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="ehcache" {
+
+	// cachedWithinFlush / cachedWithinId require >= 7.0.2.26
+	// tests use _InternalRequest into a sub-application so the BIFs
+	// are called directly (evaluate() changes UDF page context, breaking cache key identity)
+
+	private boolean function skipCachedWithin() {
+		try {
+			return !server.checkVersionGTE( server.lucee.version, 7, 0, 2, 26 );
+		} catch ( any e ) {
+			return true;
+		}
+	}
+
+	function beforeAll() {
+		variables.uri = createURI( "EHCacheCachedWithin" );
+	}
+
+	public function run( testResults, testBox ) {
+
+		describe( "CachedWithinId with EHCache", function() {
+
+			it( title: "returns a cache id for a cached function", skip: skipCachedWithin(), body: function() {
+				local.result = _InternalRequest( template: "#uri#/cachedWithinId.cfm" );
+				expect( result.filecontent.trim() ).toBe( "PASS" );
+			});
+
+		});
+
+		describe( "CachedWithinFlush with EHCache", function() {
+
+			it( title: "flushes a cached function result", skip: skipCachedWithin(), body: function() {
+				local.result = _InternalRequest( template: "#uri#/cachedWithinFlush.cfm" );
+				expect( result.filecontent.trim() ).toBe( "PASS" );
+			});
+
+			it( title: "selectively flushes only the targeted arguments", skip: skipCachedWithin(), body: function() {
+				local.result = _InternalRequest( template: "#uri#/cachedWithinFlushSelective.cfm" );
+				expect( result.filecontent.trim() ).toBe( "PASS" );
+			});
+
+			it( title: "returns false when flushing already-flushed entry", skip: skipCachedWithin(), body: function() {
+				local.result = _InternalRequest( template: "#uri#/cachedWithinFlushDouble.cfm" );
+				expect( result.filecontent.trim() ).toBe( "PASS" );
+			});
+
+		});
+
+	}
+
+	private string function createURI( string calledName ) {
+		var baseURI = contractPath( getDirectoryFromPath( getCurrenttemplatepath() ) );
+		return baseURI & "/" & calledName;
+	}
+
+}

--- a/tests/EHCacheConcurrencyTest.cfc
+++ b/tests/EHCacheConcurrencyTest.cfc
@@ -1,0 +1,121 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="ehcache" {
+
+	public function beforeAll() {
+		createCache();
+	}
+
+	public function run( testResults, testBox ) {
+
+		describe( "EHCache Concurrency", function() {
+
+			beforeEach( function() {
+				cacheClear( "", "ehcacheConcurrent" );
+			});
+
+			it( "handles concurrent puts without errors", function() {
+				var threads = {};
+				loop from="1" to="10" index="local.i" {
+					var tName = "cput_#i#";
+					threads[ tName ] = tName;
+					thread name="#tName#" i="#i#" {
+						loop from="1" to="50" index="local.j" {
+							cachePut( "conc_#i#_#j#", "val_#i#_#j#", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheConcurrent" );
+						}
+					}
+				}
+				for ( var t in threads ) {
+					thread action="join" name="#t#" timeout="30000";
+				}
+				for ( var t in threads ) {
+					if ( structKeyExists( cfthread[ t ], "error" ) ) {
+						fail( "Thread #t# errored: #cfthread[ t ].error.message#" );
+					}
+				}
+				expect( cacheCount( "ehcacheConcurrent" ) ).toBe( 500 );
+			});
+
+			it( "handles concurrent reads and writes without errors", function() {
+				// seed data
+				loop from="1" to="100" index="local.i" {
+					cachePut( "rw_#i#", "seed_#i#", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheConcurrent" );
+				}
+				var threads = {};
+				// writers
+				loop from="1" to="5" index="local.i" {
+					var tName = "writer_#i#";
+					threads[ tName ] = tName;
+					thread name="#tName#" i="#i#" {
+						loop from="1" to="100" index="local.j" {
+							cachePut( "rw_#j#", "updated_#i#_#j#", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheConcurrent" );
+						}
+					}
+				}
+				// readers
+				loop from="1" to="5" index="local.i" {
+					var tName = "reader_#i#";
+					threads[ tName ] = tName;
+					thread name="#tName#" i="#i#" {
+						loop from="1" to="100" index="local.j" {
+							cacheGet( "rw_#j#", "ehcacheConcurrent" );
+						}
+					}
+				}
+				for ( var t in threads ) {
+					thread action="join" name="#t#" timeout="30000";
+				}
+				for ( var t in threads ) {
+					if ( structKeyExists( cfthread[ t ], "error" ) ) {
+						fail( "Thread #t# errored: #cfthread[ t ].error.message#" );
+					}
+				}
+			});
+
+			it( "handles concurrent clears without errors", function() {
+				loop from="1" to="50" index="local.i" {
+					cachePut( "cc_#i#", "v", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheConcurrent" );
+				}
+				var threads = {};
+				loop from="1" to="5" index="local.i" {
+					var tName = "clr_#i#";
+					threads[ tName ] = tName;
+					thread name="#tName#" {
+						cacheClear( "", "ehcacheConcurrent" );
+					}
+				}
+				for ( var t in threads ) {
+					thread action="join" name="#t#" timeout="30000";
+				}
+				for ( var t in threads ) {
+					if ( structKeyExists( cfthread[ t ], "error" ) ) {
+						fail( "Thread #t# errored: #cfthread[ t ].error.message#" );
+					}
+				}
+				expect( cacheCount( "ehcacheConcurrent" ) ).toBe( 0 );
+			});
+
+		});
+
+	}
+
+	private function createCache() {
+		application action="update" name="ehcacheConcurrencyTest" caches={
+			"ehcacheConcurrent": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "10000",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "300",
+					"timeToLiveSeconds": "300",
+					"overflowtodisk": "true",
+					"diskpersistent": "false",
+					"maxelementsondisk": "100000",
+					"distributed": "off"
+				},
+				default: ""
+			}
+		};
+	}
+
+}

--- a/tests/EHCacheDiskTest.cfc
+++ b/tests/EHCacheDiskTest.cfc
@@ -1,0 +1,96 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="ehcache" {
+
+	public function beforeAll() {
+		createCache();
+	}
+
+	public function run( testResults, testBox ) {
+
+		describe( "EHCache Disk Overflow", function() {
+
+			beforeEach( function() {
+				cacheClear( "", "ehcacheDisk" );
+			});
+
+			it( "overflows to disk when heap is full", function() {
+				loop from="1" to="20" index="local.i" {
+					cachePut( "disk_#i#", "value_#i#", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheDisk" );
+				}
+				loop from="1" to="20" index="local.i" {
+					expect( cacheGet( "disk_#i#", "ehcacheDisk" ) ).toBe( "value_#i#" );
+				}
+				expect( cacheCount( "ehcacheDisk" ) ).toBe( 20 );
+			});
+
+			it( "serializes complex values to disk", function() {
+				// fill heap so complex value gets pushed to disk
+				loop from="1" to="10" index="local.i" {
+					cachePut( "filler_#i#", "x", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheDisk" );
+				}
+				var data = { name: "test", items: [ 1, 2, 3 ], nested: { deep: true } };
+				cachePut( "complexDisk", data, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheDisk" );
+				var result = cacheGet( "complexDisk", "ehcacheDisk" );
+				expect( result ).toBeStruct();
+				expect( result.name ).toBe( "test" );
+				expect( result.items ).toBeArray();
+				expect( result.nested.deep ).toBeTrue();
+			});
+
+			it( "includes disk entries in count", function() {
+				loop from="1" to="15" index="local.i" {
+					cachePut( "cnt_#i#", "v", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheDisk" );
+				}
+				expect( cacheCount( "ehcacheDisk" ) ).toBe( 15 );
+			});
+
+			it( "includes disk entries in key listing", function() {
+				loop from="1" to="15" index="local.i" {
+					cachePut( "dkey_#i#", "v", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheDisk" );
+				}
+				var ids = cacheGetAllIds( cacheName: "ehcacheDisk" );
+				expect( arrayLen( ids ) ).toBe( 15 );
+			});
+
+			it( "can remove entries from disk", function() {
+				loop from="1" to="15" index="local.i" {
+					cachePut( "rm_#i#", "v", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheDisk" );
+				}
+				cacheRemove( "rm_1", false, "ehcacheDisk" );
+				expect( cacheIdExists( "rm_1", "ehcacheDisk" ) ).toBeFalse();
+				expect( cacheCount( "ehcacheDisk" ) ).toBe( 14 );
+			});
+
+			it( "clears both heap and disk", function() {
+				loop from="1" to="15" index="local.i" {
+					cachePut( "clr_#i#", "v", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheDisk" );
+				}
+				cacheClear( "", "ehcacheDisk" );
+				expect( cacheCount( "ehcacheDisk" ) ).toBe( 0 );
+			});
+
+		});
+
+	}
+
+	private function createCache() {
+		application action="update" name="ehcacheDiskTest" caches={
+			"ehcacheDisk": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "10",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "300",
+					"timeToLiveSeconds": "300",
+					"overflowtodisk": "true",
+					"diskpersistent": "false",
+					"maxelementsondisk": "10000",
+					"distributed": "off"
+				},
+				default: ""
+			}
+		};
+	}
+
+}

--- a/tests/EHCacheExpiryTest.cfc
+++ b/tests/EHCacheExpiryTest.cfc
@@ -1,0 +1,160 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="ehcache" {
+
+	public function beforeAll() {
+		createCache();
+	}
+
+	public function run( testResults, testBox ) {
+
+		describe( "EHCache Expiry and Metadata", function() {
+
+			beforeEach( function() {
+				cacheClear( "", "ehcacheExpiry" );
+			});
+
+			it( "expires entries after TTL", function() {
+				cachePut( "ttlKey", "expires soon", createTimespan( 0, 0, 0, 2 ), createTimespan( 0, 0, 0, 2 ), "ehcacheExpiry" );
+				expect( cacheGet( "ttlKey", "ehcacheExpiry" ) ).toBe( "expires soon" );
+				sleep( 3000 );
+				expect( cacheIdExists( "ttlKey", "ehcacheExpiry" ) ).toBeFalse();
+			});
+
+			// config-level TTL is NOT applied when cachePut has no explicit timespan
+			// this is a known ehcache 2 issue — see https://dev.lucee.org/t/1816
+			it( title: "applies config-level TTL when cachePut has no explicit timespan", skip: true, body: function() {
+				// ehcacheShortTTL has timeToLiveSeconds=2, timeToIdleSeconds=2
+				cachePut( id: "configTTL", value: "should expire from config", cacheName: "ehcacheShortTTL" );
+				expect( cacheGet( "configTTL", "ehcacheShortTTL" ) ).toBe( "should expire from config" );
+				sleep( 3000 );
+				expect( cacheIdExists( "configTTL", "ehcacheShortTTL" ) ).toBeFalse();
+			});
+
+			it( "keeps eternal entries alive without explicit TTL", function() {
+				// ehcacheEternal has eternal=true — entries put without explicit TTL should never expire
+				// note: per-element TTL from cachePut overrides cache-level eternal in ehcache 2
+				cachePut( id: "eternalKey", value: "forever", cacheName: "ehcacheEternal" );
+				sleep( 3000 );
+				expect( cacheIdExists( "eternalKey", "ehcacheEternal" ) ).toBeTrue();
+				expect( cacheGet( "eternalKey", "ehcacheEternal" ) ).toBe( "forever" );
+			});
+
+			it( "TTI resets on access keeping entry alive", function() {
+				// TTI=3s, TTL=60s — accessing within idle window should keep it alive
+				cachePut( "ttiKey", "kept alive", createTimespan( 0, 0, 1, 0 ), createTimespan( 0, 0, 0, 3 ), "ehcacheExpiry" );
+				sleep( 2000 );
+				// access resets idle timer
+				var val = cacheGet( "ttiKey", "ehcacheExpiry" );
+				expect( val ).toBe( "kept alive" );
+				sleep( 2000 );
+				// 4s total elapsed, but only 2s since last access — within 3s TTI
+				expect( cacheIdExists( "ttiKey", "ehcacheExpiry" ) ).toBeTrue();
+			});
+
+			it( "TTI expires when entry is not accessed", function() {
+				cachePut( "ttiExpire", "will idle out", createTimespan( 0, 0, 1, 0 ), createTimespan( 0, 0, 0, 2 ), "ehcacheExpiry" );
+				expect( cacheGet( "ttiExpire", "ehcacheExpiry" ) ).toBe( "will idle out" );
+				sleep( 3000 );
+				expect( cacheIdExists( "ttiExpire", "ehcacheExpiry" ) ).toBeFalse();
+			});
+
+			it( "returns metadata with correct keys", function() {
+				cachePut( "metaKey", "metaVal", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheExpiry" );
+				// access it so we get a hit
+				cacheGet( "metaKey", "ehcacheExpiry" );
+				var meta = cacheGetMetadata( "metaKey", "ehcacheExpiry" );
+				expect( meta ).toBeStruct();
+				// entry-level keys (from CacheGetMetadata.java)
+				expect( meta ).toHaveKey( "createdtime" );
+				expect( meta ).toHaveKey( "hitcount" );
+				expect( meta ).toHaveKey( "idletime" );
+				expect( meta ).toHaveKey( "lasthit" );
+				expect( meta ).toHaveKey( "lastupdated" );
+				expect( meta ).toHaveKey( "size" );
+				expect( meta ).toHaveKey( "timespan" );
+				// cache-level keys
+				expect( meta ).toHaveKey( "cache_hitcount" );
+				expect( meta ).toHaveKey( "cache_misscount" );
+				expect( meta ).toHaveKey( "custom" );
+				// value assertions
+				expect( isDate( meta.createdtime ) ).toBeTrue();
+				expect( meta.hitcount ).toBeGTE( 1 );
+				expect( meta.size ).toBeGT( 0 );
+			});
+
+			it( "tracks count correctly", function() {
+				expect( cacheCount( "ehcacheExpiry" ) ).toBe( 0 );
+				cachePut( "cnt1", "a", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheExpiry" );
+				cachePut( "cnt2", "b", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheExpiry" );
+				expect( cacheCount( "ehcacheExpiry" ) ).toBe( 2 );
+			});
+
+			it( "isolates multiple caches", function() {
+				cacheClear( "", "ehcacheEternal" );
+				cachePut( "isoKey", "expiry", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheExpiry" );
+				cachePut( "isoKey", "eternal", createTimespan( 0, 1, 0, 0 ), createTimespan( 0, 1, 0, 0 ), "ehcacheEternal" );
+				expect( cacheGet( "isoKey", "ehcacheExpiry" ) ).toBe( "expiry" );
+				expect( cacheGet( "isoKey", "ehcacheEternal" ) ).toBe( "eternal" );
+				cacheClear( "", "ehcacheExpiry" );
+				expect( cacheIdExists( "isoKey", "ehcacheExpiry" ) ).toBeFalse();
+				expect( cacheGet( "isoKey", "ehcacheEternal" ) ).toBe( "eternal" );
+			});
+
+		});
+
+	}
+
+	private function createCache() {
+		application action="update" name="ehcacheExpiryTest" caches={
+			"ehcacheExpiry": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "1000",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "60",
+					"timeToLiveSeconds": "60",
+					"overflowtodisk": "false",
+					"diskpersistent": "false",
+					"maxelementsondisk": "0",
+					"distributed": "off"
+				},
+				default: ""
+			},
+			"ehcacheEternal": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "true",
+					"maxelementsinmemory": "1000",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "0",
+					"timeToLiveSeconds": "0",
+					"overflowtodisk": "false",
+					"diskpersistent": "false",
+					"maxelementsondisk": "0",
+					"distributed": "off"
+				},
+				default: ""
+			},
+			// only used by the skipped config-level TTL test (known ehcache 2 bug)
+			"ehcacheShortTTL": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "1000",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "2",
+					"timeToLiveSeconds": "2",
+					"overflowtodisk": "false",
+					"diskpersistent": "false",
+					"maxelementsondisk": "0",
+					"distributed": "off"
+				},
+				default: ""
+			}
+		};
+	}
+
+}

--- a/tests/EHCacheFilterTest.cfc
+++ b/tests/EHCacheFilterTest.cfc
@@ -1,0 +1,82 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="ehcache" {
+
+	public function beforeAll() {
+		createCache();
+	}
+
+	public function run( testResults, testBox ) {
+
+		describe( "EHCache Filter Operations", function() {
+
+			beforeEach( function() {
+				cacheClear( "", "ehcacheFilter" );
+			});
+
+			it( "clears entries matching a wildcard", function() {
+				cachePut( "user_1", "alice", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				cachePut( "user_2", "bob", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				cachePut( "product_1", "widget", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				cacheClear( "user_*", "ehcacheFilter" );
+				expect( cacheIdExists( "user_1", "ehcacheFilter" ) ).toBeFalse();
+				expect( cacheIdExists( "user_2", "ehcacheFilter" ) ).toBeFalse();
+				expect( cacheIdExists( "product_1", "ehcacheFilter" ) ).toBeTrue();
+			});
+
+			it( "filters getAllIds with a wildcard", function() {
+				cachePut( "alpha_1", "a", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				cachePut( "alpha_2", "b", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				cachePut( "beta_1", "c", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				var ids = cacheGetAllIds( "alpha_*", "ehcacheFilter" );
+				expect( ids ).toBeArray();
+				expect( arrayLen( ids ) ).toBe( 2 );
+			});
+
+			it( "filters getAll with a wildcard", function() {
+				cachePut( "grp_a", "one", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				cachePut( "grp_b", "two", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				cachePut( "other_c", "three", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				var all = cacheGetAll( "grp_*", "ehcacheFilter" );
+				expect( all ).toBeStruct();
+				expect( structCount( all ) ).toBe( 2 );
+			});
+
+			it( "clears all with an empty filter", function() {
+				cachePut( "ef_1", "a", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				cachePut( "ef_2", "b", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				cacheClear( "", "ehcacheFilter" );
+				expect( cacheCount( "ehcacheFilter" ) ).toBe( 0 );
+			});
+
+			it( "does not clear when filter matches nothing", function() {
+				cachePut( "keep_1", "a", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				cachePut( "keep_2", "b", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFilter" );
+				cacheClear( "nonexistent_*", "ehcacheFilter" );
+				expect( cacheCount( "ehcacheFilter" ) ).toBe( 2 );
+			});
+
+		});
+
+	}
+
+	private function createCache() {
+		application action="update" name="ehcacheFilterTest" caches={
+			"ehcacheFilter": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "1000",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "300",
+					"timeToLiveSeconds": "300",
+					"overflowtodisk": "false",
+					"diskpersistent": "false",
+					"maxelementsondisk": "0",
+					"distributed": "off"
+				},
+				default: ""
+			}
+		};
+	}
+
+}

--- a/tests/EHCacheFunctionsTest.cfc
+++ b/tests/EHCacheFunctionsTest.cfc
@@ -1,0 +1,114 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="ehcache" {
+
+	public function beforeAll() {
+		createCache();
+	}
+
+	public function run( testResults, testBox ) {
+
+		describe( "CacheDelete", function() {
+
+			beforeEach( function() {
+				cacheClear( "", "ehcacheFuncs" );
+			});
+
+			it( "deletes an existing entry", function() {
+				cachePut( "delMe", "val", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFuncs" );
+				expect( cacheIdExists( "delMe", "ehcacheFuncs" ) ).toBeTrue();
+				cacheDelete( id: "delMe", cacheName: "ehcacheFuncs" );
+				expect( cacheIdExists( "delMe", "ehcacheFuncs" ) ).toBeFalse();
+			});
+
+			it( "throws when deleting a missing entry with throwOnError", function() {
+				expect( function() {
+					cacheDelete( id: "nope_#createUUID()#", throwOnError: true, cacheName: "ehcacheFuncs" );
+				}).toThrow();
+			});
+
+			it( "does not throw when deleting a missing entry without throwOnError", function() {
+				cacheDelete( id: "nope_#createUUID()#", throwOnError: false, cacheName: "ehcacheFuncs" );
+			});
+
+		});
+
+		describe( "CacheGetProperties", function() {
+
+			it( "returns an array for object type", function() {
+				var props = cacheGetProperties( "object" );
+				expect( props ).toBeArray();
+			});
+
+			it( "returns an array with no args", function() {
+				var props = cacheGetProperties();
+				expect( props ).toBeArray();
+			});
+
+		});
+
+		describe( "CacheGetDefaultCacheName", function() {
+
+			it( "returns the default object cache name", function() {
+				var name = cacheGetDefaultCacheName( "object" );
+				expect( name ).toBeString();
+				expect( len( name ) ).toBeGT( 0 );
+			});
+
+			it( "returns the default query cache name when set", function() {
+				var name = cacheGetDefaultCacheName( "query" );
+				expect( name ).toBeString();
+				expect( len( name ) ).toBeGT( 0 );
+			});
+
+		});
+
+		describe( "CacheClear on named cache", function() {
+
+			it( "clears all entries in a named cache", function() {
+				cachePut( "scc1", "a", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheFuncs" );
+				expect( cacheCount( "ehcacheFuncs" ) ).toBeGTE( 1 );
+				cacheClear( "", "ehcacheFuncs" );
+				expect( cacheCount( "ehcacheFuncs" ) ).toBe( 0 );
+			});
+
+		});
+
+	}
+
+	private function createCache() {
+		application action="update" name="ehcacheFuncsTest" caches={
+			"ehcacheFuncs": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "1000",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "300",
+					"timeToLiveSeconds": "300",
+					"overflowtodisk": "false",
+					"diskpersistent": "false",
+					"maxelementsondisk": "0",
+					"distributed": "off"
+				},
+				default: "object"
+			},
+			"ehcacheQuery": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "1000",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "300",
+					"timeToLiveSeconds": "300",
+					"overflowtodisk": "false",
+					"diskpersistent": "false",
+					"maxelementsondisk": "0",
+					"distributed": "off"
+				},
+				default: "query"
+			}
+		};
+	}
+
+}

--- a/tests/EHCacheJDBCTest.cfc
+++ b/tests/EHCacheJDBCTest.cfc
@@ -1,0 +1,106 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="ehcache" {
+
+	variables.hasPostgres = structCount( server.getDatasource( "postgres" ) ) > 0;
+
+	public function beforeAll() {
+		if ( variables.hasPostgres ) {
+			application action="update" name="ehcacheJDBCTest" datasource=server.getDatasource( "postgres" );
+			createCache();
+			cacheClear( "", "ehcacheJDBC" );
+			cacheClear( "", "ehcacheJDBCDisk" );
+		}
+	}
+
+	public function afterAll() {
+		if ( variables.hasPostgres ) {
+			cacheClear( "", "ehcacheJDBC" );
+			cacheClear( "", "ehcacheJDBCDisk" );
+		}
+	}
+
+	private boolean function noPostgres() { return !variables.hasPostgres; }
+
+	public function run( testResults, testBox ) {
+
+		describe( "EHCache JDBC Type Caching", function() {
+
+			// LDEV-2911 regression — PGobject (jsonb) not found by ehcache classloader
+			it( title: "caches a postgres jsonb value", skip: noPostgres, body: function() {
+				var res = queryExecute( "SELECT '{""a"": ""test""}'::jsonb AS result" );
+				var jsonbVal = res.result[ 1 ];
+				cachePut( "pgJsonb", jsonbVal, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheJDBC" );
+				var cached = cacheGet( "pgJsonb", "ehcacheJDBC" );
+				expect( cached ).notToBeNull();
+			});
+
+			it( title: "caches a query with jsonb column", skip: noPostgres, body: function() {
+				var res = queryExecute( "SELECT '{""name"": ""lucee""}'::jsonb AS data, 1 AS id" );
+				cachePut( "pgQuery", res, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheJDBC" );
+				var cached = cacheGet( "pgQuery", "ehcacheJDBC" );
+				expect( isQuery( cached ) ).toBeTrue();
+				expect( cached.recordCount ).toBe( 1 );
+			});
+
+			it( title: "caches a postgres array type", skip: noPostgres, body: function() {
+				var res = queryExecute( "SELECT ARRAY[1,2,3] AS nums" );
+				cachePut( "pgArray", res, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheJDBC" );
+				var cached = cacheGet( "pgArray", "ehcacheJDBC" );
+				expect( isQuery( cached ) ).toBeTrue();
+				expect( cached.recordCount ).toBe( 1 );
+			});
+
+			// LDEV-2911 original failure path — disk deserialization of JDBC types
+			it( title: "survives disk round-trip with jsonb", skip: noPostgres, body: function() {
+				cacheClear( "", "ehcacheJDBCDisk" );
+				var res = queryExecute( "SELECT '{""key"": ""value""}'::jsonb AS data" );
+				cachePut( "pgDiskRT", res, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheJDBCDisk" );
+				// fill heap to force disk spill
+				loop from="1" to="15" index="local.i" {
+					cachePut( "filler_#i#", "x", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheJDBCDisk" );
+				}
+				var cached = cacheGet( "pgDiskRT", "ehcacheJDBCDisk" );
+				expect( isQuery( cached ) ).toBeTrue();
+			});
+
+		});
+
+	}
+
+	private function createCache() {
+		application action="update" caches={
+			"ehcacheJDBC": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "1000",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "300",
+					"timeToLiveSeconds": "300",
+					"overflowtodisk": "false",
+					"diskpersistent": "false",
+					"maxelementsondisk": "0",
+					"distributed": "off"
+				},
+				default: ""
+			},
+			"ehcacheJDBCDisk": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "10",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "300",
+					"timeToLiveSeconds": "300",
+					"overflowtodisk": "true",
+					"diskpersistent": "false",
+					"maxelementsondisk": "10000",
+					"distributed": "off"
+				},
+				default: ""
+			}
+		};
+	}
+
+}

--- a/tests/EHCacheQueryCacheTest.cfc
+++ b/tests/EHCacheQueryCacheTest.cfc
@@ -1,0 +1,86 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="ehcache" {
+
+	public function beforeAll() {
+		createCache();
+		cacheClear( "", "ehcacheQueryCache" );
+	}
+
+	public function run( testResults, testBox ) {
+
+		describe( "EHCache Query Object Serialization", function() {
+
+			beforeEach( function() {
+				cacheClear( "", "ehcacheQueryCache" );
+			});
+
+			it( "caches a query object", function() {
+				var q = queryNew( "id,val", "integer,varchar", [ [ 1, createUUID() ] ] );
+				cachePut( "qcache_test", q, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheQueryCache" );
+				var cached = cacheGet( "qcache_test", "ehcacheQueryCache" );
+				expect( isQuery( cached ) ).toBeTrue();
+				expect( cached.recordCount ).toBe( 1 );
+				expect( cached.val[ 1 ] ).toBe( q.val[ 1 ] );
+			});
+
+			it( "returns cached query on second get", function() {
+				var uuid = createUUID();
+				var q = queryNew( "id,val", "integer,varchar", [ [ 1, uuid ] ] );
+				cachePut( "qcache_hit", q, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheQueryCache" );
+				var first = cacheGet( "qcache_hit", "ehcacheQueryCache" );
+				var second = cacheGet( "qcache_hit", "ehcacheQueryCache" );
+				expect( first.val[ 1 ] ).toBe( uuid );
+				expect( second.val[ 1 ] ).toBe( uuid );
+			});
+
+			it( "caches a multi-row query", function() {
+				var q = queryNew( "id,name", "integer,varchar" );
+				loop from="1" to="100" index="local.i" {
+					queryAddRow( q, { id: i, name: "row_#i#" } );
+				}
+				cachePut( "qcache_big", q, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheQueryCache" );
+				var cached = cacheGet( "qcache_big", "ehcacheQueryCache" );
+				expect( isQuery( cached ) ).toBeTrue();
+				expect( cached.recordCount ).toBe( 100 );
+				expect( cached.name[ 50 ] ).toBe( "row_50" );
+			});
+
+			it( "caches a query with multiple column types", function() {
+				var q = queryNew(
+					"id,name,score,active,created",
+					"integer,varchar,double,bit,timestamp",
+					[ [ 1, "alice", 95.5, true, now() ] ]
+				);
+				cachePut( "qcache_types", q, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheQueryCache" );
+				var cached = cacheGet( "qcache_types", "ehcacheQueryCache" );
+				expect( isQuery( cached ) ).toBeTrue();
+				expect( cached.name[ 1 ] ).toBe( "alice" );
+				expect( cached.score[ 1 ] ).toBe( 95.5 );
+				expect( cached.active[ 1 ] ).toBeTrue();
+			});
+
+		});
+
+	}
+
+	private function createCache() {
+		application action="update" name="ehcacheQueryCacheTest" caches={
+			"ehcacheQueryCache": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "1000",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "300",
+					"timeToLiveSeconds": "300",
+					"overflowtodisk": "false",
+					"diskpersistent": "false",
+					"maxelementsondisk": "0",
+					"distributed": "off"
+				},
+				default: "query"
+			}
+		};
+	}
+
+}

--- a/tests/EHCacheScaleTest.cfc
+++ b/tests/EHCacheScaleTest.cfc
@@ -1,0 +1,83 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="ehcache" {
+
+	public function beforeAll() {
+		createCache();
+	}
+
+	public function run( testResults, testBox ) {
+
+		describe( "EHCache Scale", function() {
+
+			beforeEach( function() {
+				cacheClear( "", "ehcacheScale" );
+			});
+
+			it( "handles 1000 entries", function() {
+				loop from="1" to="1000" index="local.i" {
+					cachePut( "scale_#i#", "value_#i#", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheScale" );
+				}
+				expect( cacheCount( "ehcacheScale" ) ).toBe( 1000 );
+				expect( cacheGet( "scale_1", "ehcacheScale" ) ).toBe( "value_1" );
+				expect( cacheGet( "scale_500", "ehcacheScale" ) ).toBe( "value_500" );
+				expect( cacheGet( "scale_1000", "ehcacheScale" ) ).toBe( "value_1000" );
+			});
+
+			it( "lists 1000 keys", function() {
+				loop from="1" to="1000" index="local.i" {
+					cachePut( "ks_#i#", "v", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheScale" );
+				}
+				var ids = cacheGetAllIds( cacheName: "ehcacheScale" );
+				expect( arrayLen( ids ) ).toBe( 1000 );
+			});
+
+			it( "clears 1000 entries", function() {
+				loop from="1" to="1000" index="local.i" {
+					cachePut( "cs_#i#", "v", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheScale" );
+				}
+				expect( cacheCount( "ehcacheScale" ) ).toBe( 1000 );
+				cacheClear( "", "ehcacheScale" );
+				expect( cacheCount( "ehcacheScale" ) ).toBe( 0 );
+			});
+
+			it( "caches a large value", function() {
+				var bigVal = repeatString( "x", 100000 );
+				cachePut( "bigValue", bigVal, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheScale" );
+				var result = cacheGet( "bigValue", "ehcacheScale" );
+				expect( len( result ) ).toBe( 100000 );
+			});
+
+			it( "evicts to disk when heap is full", function() {
+				loop from="1" to="6000" index="local.i" {
+					cachePut( "evict_#i#", "v_#i#", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheScale" );
+				}
+				expect( cacheCount( "ehcacheScale" ) ).toBe( 6000 );
+				expect( cacheGet( "evict_1", "ehcacheScale" ) ).toBe( "v_1" );
+				expect( cacheGet( "evict_6000", "ehcacheScale" ) ).toBe( "v_6000" );
+			});
+
+		});
+
+	}
+
+	private function createCache() {
+		application action="update" name="ehcacheScaleTest" caches={
+			"ehcacheScale": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "5000",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "300",
+					"timeToLiveSeconds": "300",
+					"overflowtodisk": "true",
+					"diskpersistent": "false",
+					"maxelementsondisk": "100000",
+					"distributed": "off"
+				},
+				default: ""
+			}
+		};
+	}
+
+}

--- a/tests/EHCacheTypesTest.cfc
+++ b/tests/EHCacheTypesTest.cfc
@@ -1,0 +1,143 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="ehcache" {
+
+	public function beforeAll() {
+		createCache();
+	}
+
+	public function run( testResults, testBox ) {
+
+		describe( "EHCache Type Serialization", function() {
+
+			beforeEach( function() {
+				cacheClear( "", "ehcacheTypes" );
+			});
+
+			it( "caches a string", function() {
+				cachePut( "typeStr", "hello world", createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheTypes" );
+				var result = cacheGet( "typeStr", "ehcacheTypes" );
+				expect( result ).toBe( "hello world" );
+				expect( isSimpleValue( result ) ).toBeTrue();
+			});
+
+			it( "caches a number", function() {
+				cachePut( "typeNum", 42.5, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheTypes" );
+				expect( cacheGet( "typeNum", "ehcacheTypes" ) ).toBe( 42.5 );
+			});
+
+			it( "caches a boolean", function() {
+				cachePut( "typeBool", true, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheTypes" );
+				expect( cacheGet( "typeBool", "ehcacheTypes" ) ).toBeTrue();
+			});
+
+			it( "caches a date", function() {
+				var dt = now();
+				cachePut( "typeDate", dt, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheTypes" );
+				expect( dateCompare( cacheGet( "typeDate", "ehcacheTypes" ), dt ) ).toBe( 0 );
+			});
+
+			it( "caches a struct", function() {
+				var data = { name: "Zac", role: "dev", score: 99 };
+				cachePut( "typeStruct", data, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheTypes" );
+				var result = cacheGet( "typeStruct", "ehcacheTypes" );
+				expect( result ).toBeStruct();
+				expect( result.name ).toBe( "Zac" );
+				expect( result.role ).toBe( "dev" );
+				expect( result.score ).toBe( 99 );
+			});
+
+			it( "caches an array", function() {
+				var data = [ "a", "b", "c", 1, 2, 3 ];
+				cachePut( "typeArr", data, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheTypes" );
+				var result = cacheGet( "typeArr", "ehcacheTypes" );
+				expect( result ).toBeArray();
+				expect( arrayLen( result ) ).toBe( 6 );
+				expect( result[ 1 ] ).toBe( "a" );
+				expect( result[ 6 ] ).toBe( 3 );
+			});
+
+			it( "caches a query", function() {
+				var qry = queryNew( "id,name", "integer,varchar", [ [ 1, "alpha" ], [ 2, "bravo" ], [ 3, "charlie" ] ] );
+				cachePut( "typeQuery", qry, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheTypes" );
+				var result = cacheGet( "typeQuery", "ehcacheTypes" );
+				expect( isQuery( result ) ).toBeTrue();
+				expect( result.recordCount ).toBe( 3 );
+				expect( result.name[ 2 ] ).toBe( "bravo" );
+			});
+
+			// LDEV-4498 regression
+			it( "preserves ordered struct key order", function() {
+				var data = structNew( "ordered" );
+				data[ "second" ] = 2;
+				data[ "first" ] = 1;
+				data[ "third" ] = 3;
+				cachePut( "typeOrdered", data, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheTypes" );
+				var result = cacheGet( "typeOrdered", "ehcacheTypes" );
+				expect( result ).toBeStruct();
+				var keys = structKeyArray( result );
+				expect( keys[ 1 ] ).toBe( "second" );
+				expect( keys[ 2 ] ).toBe( "first" );
+				expect( keys[ 3 ] ).toBe( "third" );
+			});
+
+			it( "caches nested complex values", function() {
+				var data = {
+					users: [
+						{ name: "Alice", tags: [ "admin", "dev" ] },
+						{ name: "Bob", tags: [ "user" ] }
+					],
+					meta: { count: 2, active: true }
+				};
+				cachePut( "typeNested", data, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheTypes" );
+				var result = cacheGet( "typeNested", "ehcacheTypes" );
+				expect( result.users ).toBeArray();
+				expect( arrayLen( result.users ) ).toBe( 2 );
+				expect( result.users[ 1 ].name ).toBe( "Alice" );
+				expect( result.users[ 1 ].tags[ 2 ] ).toBe( "dev" );
+				expect( result.meta.count ).toBe( 2 );
+				expect( result.meta.active ).toBeTrue();
+			});
+
+			it( "caches binary data", function() {
+				var data = toBinary( toBase64( "binary content here" ) );
+				cachePut( "typeBinary", data, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheTypes" );
+				var result = cacheGet( "typeBinary", "ehcacheTypes" );
+				expect( isBinary( result ) ).toBeTrue();
+				expect( toString( result ) ).toBe( "binary content here" );
+			});
+
+			// LDEV-4429 regression
+			it( "caches a QueryStruct", function() {
+				var qry = queryNew( "foo", "varchar", [ [ "foo1" ], [ "foo2" ] ] );
+				var qs = queryExecute( "SELECT foo FROM qry", {}, { dbtype: "query", returnType: "struct", columnKey: "foo" } );
+				cachePut( "typeQueryStruct", qs, createTimespan( 0, 0, 5, 0 ), createTimespan( 0, 0, 5, 0 ), "ehcacheTypes" );
+				var result = cacheGet( "typeQueryStruct", "ehcacheTypes" );
+				expect( result.getClass().getName() ).toBe( "lucee.runtime.type.query.QueryStruct" );
+				expect( result.getRecordCount() ).toBe( 2 );
+			});
+
+		});
+
+	}
+
+	private function createCache() {
+		application action="update" name="ehcacheTypesTest" caches={
+			"ehcacheTypes": {
+				class: "org.lucee.extension.cache.eh.EHCache",
+				storage: false,
+				custom: {
+					"eternal": "false",
+					"maxelementsinmemory": "1000",
+					"memoryevictionpolicy": "LRU",
+					"timeToIdleSeconds": "300",
+					"timeToLiveSeconds": "300",
+					"overflowtodisk": "true",
+					"diskpersistent": "false",
+					"maxelementsondisk": "10000",
+					"distributed": "off"
+				},
+				default: ""
+			}
+		};
+	}
+
+}


### PR DESCRIPTION
## Summary

- Added 16 new test files (1349 lines) covering all Lucee cache BIFs against EHCache
- Reworked CI workflow: build once, test matrix (6.x, 7.0, 7.1), explicit deploy gate
- Added Postgres setup in CI for JDBC type caching tests (LDEV-2911)

### Test coverage

| Test file | What it covers |
|-----------|---------------|
| BasicTest | put/get, contains, remove, clear, count, keys, overwrite |
| TypesTest | string, number, bool, date, struct, array, query, ordered struct (LDEV-4498), nested, binary, QueryStruct (LDEV-4429) |
| ExpiryTest | TTL, TTI reset on access, eternal, metadata keys, cache isolation |
| DiskTest | overflow to disk, complex values on disk, count/keys/remove/clear across heap+disk |
| FilterTest | wildcard clear/getAllIds/getAll, empty filter, no-match filter |
| ConcurrencyTest | 10 threads x 50 puts, concurrent read+write, concurrent clears |
| ScaleTest | 1000 entries, 100KB values, 6000 entries forcing eviction |
| JDBCTest | postgres jsonb/array types, disk round-trip (LDEV-2911). Skips without postgres |
| FunctionsTest | cacheDelete (with throwOnError), cacheGetProperties, cacheGetDefaultCacheName |
| QueryCacheTest | query object serialisation round-trips |
| CachedWithinTest | cachedWithinId, cachedWithinFlush (version gated >= 7.0.2.26) |

### Known issues documented

- Config-level TTL not applied when `cachePut` has no explicit timespan (skipped test, known ehcache 2 bug)
- Per-element TTL overrides cache-level `eternal` flag in ehcache 2

## Test plan

- [x] All tests pass locally on 6.x, 7.0, 7.1
- [x] CI green: https://github.com/lucee/extension-ehcache/actions/runs/24452241913